### PR TITLE
fix: exclude commons-logging to avoid conflict with spring-jcl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
             <groupId>com.solacesystems</groupId>
             <artifactId>sol-jcsmp</artifactId>
             <version>${solace.jcsmp.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- Avoid conflict with spring-jcl -->
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.solace.spring.boot</groupId>


### PR DESCRIPTION
Exclude transitive commons-logging dependency in order to avoid conflict with spring-jcl.

This fixes the following warning on application startup: "Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts".