### PR TITLE
fix false positive "messages is still in progress" log warn message

### DIFF
--- a/src/test/java/com/solace/spring/cloud/stream/binder/inbound/queue/FlowXMLMessageListenerTest.java
+++ b/src/test/java/com/solace/spring/cloud/stream/binder/inbound/queue/FlowXMLMessageListenerTest.java
@@ -1,6 +1,8 @@
 package com.solace.spring.cloud.stream.binder.inbound.queue;
 
 import com.solacesystems.jcsmp.BytesXMLMessage;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.Topic;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -58,6 +60,9 @@ class FlowXMLMessageListenerTest {
 
         // Simulate a message being received
         BytesXMLMessage mockMessage = mock(BytesXMLMessage.class);
+        Mockito.when(mockMessage.getMessageId()).thenReturn("TestMessageId");
+        Mockito.when(mockMessage.getDestination()).thenReturn(JCSMPFactory.onlyInstance().createTopic("test/topic"));
+
         listener.onReceive(mockMessage);
 
         // Wait briefly to allow message to be processed
@@ -95,6 +100,9 @@ class FlowXMLMessageListenerTest {
         long start = System.nanoTime();
         for (int i = 0; i < 20; i++) {
             BytesXMLMessage mockMessage = mock(BytesXMLMessage.class);
+            Mockito.when(mockMessage.getMessageId()).thenReturn("TestMessageId");
+            Mockito.when(mockMessage.getDestination()).thenReturn(JCSMPFactory.onlyInstance().createTopic("test/topic"));
+
             listener.onReceive(mockMessage);
         }
         long afterSend = System.nanoTime();
@@ -134,6 +142,7 @@ class FlowXMLMessageListenerTest {
         // Simulate a message being received
         BytesXMLMessage mockMessage = mock(BytesXMLMessage.class);
         Mockito.when(mockMessage.getMessageId()).thenReturn("TestMessageId");
+        Mockito.when(mockMessage.getDestination()).thenReturn(JCSMPFactory.onlyInstance().createTopic("test/topic"));
         listener.onReceive(mockMessage);
 
 


### PR DESCRIPTION
- fix false positive "messages is still in progress" log warn message
- introduce log trace to better understand where is how many time spend

@helios57 In my opinion we should discuss this warn message again.
Example:
- A binder has 'spring.cloud.stream.bindings.receiveTemperatureSensorSimple-in-0.consumer.concurrency = 10`
- The message rate is one message every 5 seconds
- The average message processing time is 25 seconds

In this example we use ~5 of 10 threads and never have back pressure to the flow / aka now reason for a warning.