### PR TITLE
having version explicit where-ever possible to reduce complexity …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>2.0.2</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>
@@ -185,6 +178,7 @@
                 <dependency>
                     <groupId>org.testcontainers</groupId>
                     <artifactId>testcontainers</artifactId>
+                    <version>2.0.2</version>
                 </dependency>
                 <dependency>
                     <groupId>org.junit.jupiter</groupId>
@@ -193,6 +187,7 @@
                 <dependency>
                     <groupId>org.testcontainers</groupId>
                     <artifactId>testcontainers-junit-jupiter</artifactId>
+                    <version>2.0.2</version>
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.boot</groupId>
@@ -201,6 +196,7 @@
                 <dependency>
                     <groupId>org.testcontainers</groupId>
                     <artifactId>testcontainers-toxiproxy</artifactId>
+                    <version>2.0.2</version>
                 </dependency>
                 <dependency>
                     <groupId>com.squareup.okhttp3</groupId>


### PR DESCRIPTION
...alongside springs old dependencies.

The spring parent bom usually has old versions. Since it is on the same level as other dependency-management entries, often the result is not expected / not clearly visible. Even mvn dependency:analyze don't always reveal the reason for what dependency results in the final package and has difficulty revealing why.

For those reasons the version is explicitly set to at least get consistent results within binder builds.