### PR TITLE
STTRS-3200: send-retry for outbound publishes (opt-out)

### DIFF
--- a/API.md
+++ b/API.md
@@ -521,6 +521,14 @@ See [SolaceCommonProperties](src/main/java/com/solace/spring/cloud/stream/binder
     Default: `null` (If unconfigured, the producer flow inherits `solace.java.apiProperties.PUB_ACK_WINDOW_SIZE` / the JCSMP session default.)
     See: [ProducerFlowProperties.setWindowSize(int)](https://docs.solace.com/API-Developer-Online-Ref-Documentation/java/com/solacesystems/jcsmp/ProducerFlowProperties.html#setWindowSize(int))
 
+`sendRetryTimeoutMs`
+:   Time window in milliseconds during which a failed synchronous publish is retried before the send ultimately fails. When a publish attempt throws, the binder keeps retrying (with a 1 second back-off between attempts) until this duration elapses, after which it re-throws the failure as an `org.springframework.messaging.MessagingException`.
+    Set to `0` to disable retrying: the outbound message handler then performs a single publish attempt and immediately propagates any failure as a `org.springframework.messaging.MessagingException`.
+    Default: `60000` (60 seconds)
+
+> [!IMPORTANT]
+> Retrying only mitigates *transient*, synchronous publish failures. Regardless of `sendRetryTimeoutMs`, a call to `StreamBridge.send(...)` (and therefore the binder's outbound message handler) can still throw an `org.springframework.messaging.MessagingException` — for example once the retry window is exhausted, or when the message cannot be mapped/serialized, or when the producer binding is not running. **Producers must always be prepared to catch `org.springframework.messaging.MessagingException`.** See the binder examples for the recommended pattern.
+
 #### Solace Connection Health-Check Properties
 
 The Solace connection health indicator immediately reports `DOWN` status when the connection is down or reconnecting. This ensures that health checks accurately reflect the current connection state without any delay or threshold configuration.
@@ -1046,6 +1054,17 @@ spring:
 By default, asynchronous producer errors aren't handled by the framework. Producer error channels can be enabled using the [`errorChannelEnabled` producer config option](https://docs.spring.io/spring-cloud-stream/docs/current/reference/html/spring-cloud-stream.html#_producer_properties).
 
 Beyond that, this binder also supports using a `Future` to wait for publish confirmations. See [Publisher Confirms](#publisher-confirms) for more info.
+
+> [!IMPORTANT]
+> A synchronous call to `StreamBridge.send(...)` (and to any producer binding backed by this binder) can throw an `org.springframework.messaging.MessagingException`. This happens, for example, when the producer binding is not running, when a message cannot be mapped/serialized, or when publishing keeps failing until the [`sendRetryTimeoutMs`](#solace-producer-properties) retry window is exhausted. With `sendRetryTimeoutMs` (default `60000`) the binder first retries transient publish failures; once the window elapses it re-throws the failure as a `MessagingException`. Setting `sendRetryTimeoutMs: 0` disables retrying and propagates the failure immediately. **Regardless of the retry setting, producers must always wrap `StreamBridge.send(...)` in a `try/catch` for `org.springframework.messaging.MessagingException`.**
+>
+> ```java
+> try {
+>     streamBridge.send("output-destination", message);
+> } catch (org.springframework.messaging.MessagingException e) {
+>     // Handle the failed publish (retry at a higher level, alert, drop, ...).
+> }
+> ```
 
 ## Publisher Confirmations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [9.3.0] - 2026-08-11
+
+### Added
+- Added `sendRetryTimeoutMs` producer property (default `60000`). Failed synchronous publishes (`producer.send(...)`) are now retried with a 1 second back-off until this window elapses, after which the failure is re-thrown as an `org.springframework.messaging.MessagingException`. Set `sendRetryTimeoutMs: 0` to disable retrying and propagate failures immediately (previous behaviour).
+
+### Changed
+- Documented that `StreamBridge.send(...)` / the outbound message handler can throw an `org.springframework.messaging.MessagingException` (including in the binder examples). Producers must always catch it, even with `sendRetryTimeoutMs` enabled.
 
 ## [9.2.0] - 2026-06-25
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,29 @@ This document contains migration guides for major version upgrades of the Spring
 
 ---
 
+## 9.x.0 to 9.3.0
+
+### Fix previously unreliable behavior of error handling on sending messages
+If you rely on the behavior that on the first seconds a broker can not be reached your outgoing messages must be lost, you must set the new producer property `sendRetryTimeoutMs: 0` to disable retrying and propagate failures immediately.
+Otherwise, the default behavior is to retry failed synchronous publishes (`producer.send(...)`) with a 1 second back-off until the `sendRetryTimeoutMs` window elapses (default 60000 ms), after which the failure is re-thrown as an `org.springframework.messaging.MessagingException`.
+
+When you have low ttl since your messages will be sent in regular intervals, and the retry is within this range it makes no sense to retry over this, so you might want to disable for such a producer.
+
+Example configuration:
+```yaml
+spring:
+    cloud:
+        stream:
+            bindings:
+                <binding-name-a>:
+                # ... non-solace specific properties
+            solace:
+                bindings:
+                    <binding-name-a>:
+                        producer:
+                            sendRetryTimeoutMs: 0 # Disabled retry of unsuccessful send attempts
+```
+
 ## 8.0.0 to 9.0.0
 
 > [!IMPORTANT]

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,8 @@ This repository contains **21 distinct, production-ready examples** demonstratin
 
 Unless an example is explicitly demonstrating a different transport behavior, the publisher samples send outbound messages with a 30 second TTL and `solace_dmqEligible=true` so they stay aligned with the binder header guidance in [API.md](../API.md).
 
+Every publisher sample wraps `streamBridge.send(...)` in a `try/catch` for `org.springframework.messaging.MessagingException`. The call is synchronous and can throw once the producer's `sendRetryTimeoutMs` (default `60000`, set `0` to disable) retry window is exhausted, so producers must always be prepared to catch it — the REST-driven samples (`dynamic-destinations`, `pause-resume-bindings`) translate the failure into an HTTP `503` instead of parking the request thread. See [Failed Producer Message Error Handling](../API.md#failed-producer-message-error-handling).
+
 ## Prerequisites
 To run these examples locally without the integration test framework, you will need access to a Solace PubSub+ Event Broker.
 You can easily spin one up via Docker:

--- a/examples/basic-publish-subscribe/README.md
+++ b/examples/basic-publish-subscribe/README.md
@@ -73,16 +73,25 @@ public class BasicApp {
     @Scheduled(fixedRate = 2000)
     public void publish() {
         String msg = "Hello from Solace #" + count.getAndIncrement();
-      streamBridge.send("source-out-0", MessageBuilder.withPayload(msg)
-          .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis()) // Prefer always Duration over raw millis for readability and avoid confusion about time units.
-          .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-          .build());
-        log.info("Published: {}", msg);
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs
+        // window is exhausted), so always wrap the publish in a try/catch even though the binder retries
+        // transient failures for up to `sendRetryTimeoutMs` (default 60000).
+        try {
+          streamBridge.send("source-out-0", MessageBuilder.withPayload(msg)
+              .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis()) // Prefer always Duration over raw millis for readability and avoid confusion about time units.
+              .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+              .build());
+          log.info("Published: {}", msg);
+        } catch (MessagingException e) {
+          log.error("Failed to publish: {}", msg, e);
+        }
     }
 }
 ```
 
   A scheduled task executes every 2 seconds, independently publishing messages using the injected `StreamBridge`. Each outbound message gets a 30 second TTL and `solace_dmqEligible=true`, so expired durable messages remain eligible for a DMQ.
+
+  Note that `streamBridge.send(...)` is wrapped in a `try/catch` for `org.springframework.messaging.MessagingException`. The binder retries transient publish failures for up to the producer's `sendRetryTimeoutMs` (default `60000`, set `0` to disable), but once that window is exhausted the failure is re-thrown as a `MessagingException` — so producers must always be prepared to catch it. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 ```java
 @Bean

--- a/examples/basic-publish-subscribe/pom.xml
+++ b/examples/basic-publish-subscribe/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-basic-publish-subscribe</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Basic Publish Subscribe</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/basic-publish-subscribe/src/main/java/ch/sbb/example/BasicApp.java
+++ b/examples/basic-publish-subscribe/src/main/java/ch/sbb/example/BasicApp.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -34,11 +35,17 @@ public class BasicApp {
     @Scheduled(fixedRate = 2000)
     public void publish() {
         String msg = "Hello from Solace #" + count.getAndIncrement();
-        streamBridge.send("source-out-0", MessageBuilder.withPayload(msg)
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        log.info("Published: {}", msg);
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window
+        // is exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("source-out-0", MessageBuilder.withPayload(msg)
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            log.info("Published: {}", msg);
+        } catch (MessagingException e) {
+            log.error("Failed to publish: {}", msg, e);
+        }
     }
 
     @Bean

--- a/examples/consumer-concurrency/README.md
+++ b/examples/consumer-concurrency/README.md
@@ -70,10 +70,14 @@ public class ConcurrencyApp {
         if (burstPublished.compareAndSet(false, true)) {
             for (int messageIndex = 1; messageIndex <= 20; messageIndex++) {
           String payload = "msg-" + messageIndex;
-          streamBridge.send("fastPublisher-out-0", MessageBuilder.withPayload(payload)
-              .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-              .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-              .build());
+          try {
+            streamBridge.send("fastPublisher-out-0", MessageBuilder.withPayload(payload)
+                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                .build());
+          } catch (MessagingException e) {
+            log.error("Failed to publish {}", payload, e);
+          }
             }
             log.info("Finished publishing 20 messages in burst");
         }
@@ -81,7 +85,7 @@ public class ConcurrencyApp {
 }
 ```
 
-  Publishes a single 20-message burst shortly after startup, then stops. The burst messages carry a 30 second TTL and `solace_dmqEligible=true`, which keeps the example aligned with the durable-message header guidance while still creating enough backlog for parallel processing.
+  Publishes a single 20-message burst shortly after startup, then stops. The burst messages carry a 30 second TTL and `solace_dmqEligible=true`, which keeps the example aligned with the durable-message header guidance while still creating enough backlog for parallel processing. Each `streamBridge.send(...)` is wrapped in a `try/catch` for `org.springframework.messaging.MessagingException` — the call is synchronous and can throw once the producer's `sendRetryTimeoutMs` (default `60000`) is exhausted, so guarding it per message keeps one failed publish from aborting the rest of the burst. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 ```java
 @Bean

--- a/examples/consumer-concurrency/pom.xml
+++ b/examples/consumer-concurrency/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-consumer-concurrency</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Consumer Concurrency</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/consumer-concurrency/src/main/java/ch/sbb/example/ConcurrencyApp.java
+++ b/examples/consumer-concurrency/src/main/java/ch/sbb/example/ConcurrencyApp.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -34,12 +35,18 @@ public class ConcurrencyApp {
     @Scheduled(initialDelay = 1000, fixedDelay = 60000)
     public void publishBurst() {
         if (burstPublished.compareAndSet(false, true)) {
+            // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window
+            // is exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
             for (int messageIndex = 1; messageIndex <= 20; messageIndex++) {
                 String payload = "msg-" + messageIndex;
-                streamBridge.send("fastPublisher-out-0", MessageBuilder.withPayload(payload)
-                        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                        .build());
+                try {
+                    streamBridge.send("fastPublisher-out-0", MessageBuilder.withPayload(payload)
+                            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                            .build());
+                } catch (MessagingException e) {
+                    log.error("Failed to publish {}", payload, e);
+                }
             }
             log.info("Finished publishing 20 messages in burst");
         }

--- a/examples/consumer-groups/pom.xml
+++ b/examples/consumer-groups/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-consumer-groups</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Consumer Groups</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/consumer-groups/src/main/java/ch/sbb/example/ConsumerGroupsApp.java
+++ b/examples/consumer-groups/src/main/java/ch/sbb/example/ConsumerGroupsApp.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -35,11 +36,17 @@ public class ConsumerGroupsApp {
     @Scheduled(fixedRate = 2000)
     public void publish() {
         String msg = "group-msg-" + count.getAndIncrement();
-        streamBridge.send("publisher-out-0", MessageBuilder.withPayload(msg)
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        log.info("Published: {}", msg);
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("publisher-out-0", MessageBuilder.withPayload(msg)
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            log.info("Published: {}", msg);
+        } catch (MessagingException e) {
+            log.error("Failed to publish: {}", msg, e);
+        }
     }
 
     @Bean

--- a/examples/default-headers/README.md
+++ b/examples/default-headers/README.md
@@ -82,13 +82,14 @@ public void publish() {
                 .build();
     }
 
-    streamBridge.send("headerPublisher-out-0", message);
+    streamBridge.send("headerPublisher-out-0", message); // (3)
     log.info("Published message {}", index);
 }
 ```
 
 1. **Fallback to default** — Even-indexed messages do not set `custom-default-header`, so the binder fills it in from `default-header.custom-default-header`. The Solace headers `solace_timeToLive` and `solace_senderId` are also injected automatically.
 2. **Override** — Odd-indexed messages set `custom-default-header` explicitly. The configured default is silently skipped for that header on that message; other defaults still apply.
+3. **Wrap the publish in `try/catch`** — `streamBridge.send(...)` is synchronous and can throw an `org.springframework.messaging.MessagingException` (for example once the producer's `sendRetryTimeoutMs`, default `60000`, is exhausted). The full sample wraps the call in a `try/catch (MessagingException e)` and logs the failure; producers must always be prepared to catch it. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 ### Consumer — Reading the Resulting Headers
 

--- a/examples/default-headers/pom.xml
+++ b/examples/default-headers/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-default-headers</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Default Headers</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/default-headers/src/main/java/ch/sbb/example/DefaultHeadersApp.java
+++ b/examples/default-headers/src/main/java/ch/sbb/example/DefaultHeadersApp.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -50,8 +51,14 @@ public class DefaultHeadersApp {
                     .build();
         }
 
-        streamBridge.send("headerPublisher-out-0", message);
-        log.info("Published message {}", index);
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("headerPublisher-out-0", message);
+            log.info("Published message {}", index);
+        } catch (MessagingException e) {
+            log.error("Failed to publish message {}", index, e);
+        }
     }
 
     @Bean

--- a/examples/dynamic-destinations/README.md
+++ b/examples/dynamic-destinations/README.md
@@ -62,18 +62,25 @@ public class DynamicDestinationsApp {
     private final StreamBridge streamBridge;
 
     @PostMapping("/send")
-    public String publish(@RequestParam String destination, @RequestBody String payload) {
+    public ResponseEntity<String> publish(@RequestParam String destination, @RequestBody String payload) {
         log.info("Publishing to dynamic destination '{}': {}", destination, payload);
-      streamBridge.send(destination, MessageBuilder.withPayload(payload)
-          .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-          .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-          .build());                         // (1)
-        return "Sent to " + destination;
+        try {
+          streamBridge.send(destination, MessageBuilder.withPayload(payload)
+              .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+              .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+              .build());                         // (1)
+          return ResponseEntity.ok("Sent to " + destination);
+        } catch (MessagingException e) {         // (2)
+          log.error("Failed to publish to dynamic destination '{}': {}", destination, payload, e);
+          return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+              .body("Failed to send to " + destination + ": " + e.getMessage());
+        }
     }
 }
 ```
 
   1. **`streamBridge.send(destination, message)`** — `StreamBridge` is Spring Cloud Stream's API for sending messages without pre-configured bindings. The `destination` parameter becomes the Solace topic the message is published to, while the `Message<?>` envelope lets the sample apply the same 30 second TTL and DMQ-eligibility defaults as the rest of the suite. The binder creates an ephemeral producer binding on the fly.
+  2. **`catch (MessagingException e)`** — `streamBridge.send(...)` is a synchronous call that can throw an `org.springframework.messaging.MessagingException`. Because we publish straight from the request thread, the binder's `sendRetryTimeoutMs` (default `60000`, set `0` to disable) would otherwise park this request for up to a minute before the failure surfaced unhandled. Always catch it and translate the failure into a proper HTTP error response. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 ```java
 @Bean

--- a/examples/dynamic-destinations/pom.xml
+++ b/examples/dynamic-destinations/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-dynamic-destinations</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Dynamic Destinations</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/dynamic-destinations/src/main/java/ch/sbb/example/DynamicDestinationsApp.java
+++ b/examples/dynamic-destinations/src/main/java/ch/sbb/example/DynamicDestinationsApp.java
@@ -7,6 +7,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,13 +39,22 @@ public class DynamicDestinationsApp {
     }
 
     @PostMapping("/send")
-    public String publish(@RequestParam String destination, @RequestBody String payload) {
+    public ResponseEntity<String> publish(@RequestParam String destination, @RequestBody String payload) {
         log.info("Publishing to dynamic destination '{}': {}", destination, payload);
-        streamBridge.send(destination, MessageBuilder.withPayload(payload)
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        return "Sent to " + destination;
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted). Since we publish straight from this request thread, always catch it and turn it into a proper
+        // HTTP error response instead of letting the request fail with an unhandled exception.
+        try {
+            streamBridge.send(destination, MessageBuilder.withPayload(payload)
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            return ResponseEntity.ok("Sent to " + destination);
+        } catch (MessagingException e) {
+            log.error("Failed to publish to dynamic destination '{}': {}", destination, payload, e);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body("Failed to send to " + destination + ": " + e.getMessage());
+        }
     }
 
     @Bean

--- a/examples/error-handling-error-queue/pom.xml
+++ b/examples/error-handling-error-queue/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-error-handling-error-queue</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Error Handling Error Queue</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/error-handling-error-queue/src/main/java/ch/sbb/example/ErrorQueueApp.java
+++ b/examples/error-handling-error-queue/src/main/java/ch/sbb/example/ErrorQueueApp.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -30,11 +31,17 @@ public class ErrorQueueApp {
 
     @Scheduled(fixedRate = 5000)
     public void publishErrorTrigger() {
-        streamBridge.send("errorProducer-out-0", MessageBuilder.withPayload("fail-me")
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        log.info("Published message that will fail");
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("errorProducer-out-0", MessageBuilder.withPayload("fail-me")
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            log.info("Published message that will fail");
+        } catch (MessagingException e) {
+            log.error("Failed to publish message that will fail", e);
+        }
     }
 
     @Bean

--- a/examples/error-handling-redelivery/pom.xml
+++ b/examples/error-handling-redelivery/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-error-handling-redelivery</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Error Handling Redelivery</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/error-handling-redelivery/src/main/java/ch/sbb/example/RedeliveryApp.java
+++ b/examples/error-handling-redelivery/src/main/java/ch/sbb/example/RedeliveryApp.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -36,11 +37,17 @@ public class RedeliveryApp {
     @Scheduled(initialDelay = 1000, fixedDelay = 60000)
     public void publish() {
         if (published.compareAndSet(false, true)) {
-            streamBridge.send("retryProducer-out-0", MessageBuilder.withPayload("retry-me")
-                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                    .build());
-            log.info("Published message designed for retry and broker redelivery");
+            // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window
+            // is exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+            try {
+                streamBridge.send("retryProducer-out-0", MessageBuilder.withPayload("retry-me")
+                        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                        .build());
+                log.info("Published message designed for retry and broker redelivery");
+            } catch (MessagingException e) {
+                log.error("Failed to publish message designed for retry and broker redelivery", e);
+            }
         }
     }
 

--- a/examples/health-indicator/pom.xml
+++ b/examples/health-indicator/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-health-indicator</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Health Indicator</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/large-message-chunking/pom.xml
+++ b/examples/large-message-chunking/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-large-message-chunking</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Large Message Chunking</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/large-message-chunking/src/main/java/ch/sbb/example/LargeMessageApp.java
+++ b/examples/large-message-chunking/src/main/java/ch/sbb/example/LargeMessageApp.java
@@ -8,6 +8,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -24,7 +25,7 @@ public class LargeMessageApp {
     public static final BlockingQueue<String> RECEIVED = new LinkedBlockingQueue<>();
     private final StreamBridge streamBridge;
     private final String largePayload;
-    
+
     public LargeMessageApp(StreamBridge streamBridge) {
         this.streamBridge = streamBridge;
         this.largePayload = "A".repeat(1024 * 1024); // 1 MB payload
@@ -34,13 +35,19 @@ public class LargeMessageApp {
 
     @Scheduled(fixedRate = 5000)
     public void publishLargeMessage() {
-        streamBridge.send("chunkedPublisher-out-0",
-                MessageBuilder.withPayload(largePayload)
-                        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                        .setHeader(SolaceBinderHeaders.LARGE_MESSAGE_SUPPORT, true)
-                        .build());
-        log.info("Published large message of {} bytes", largePayload.length());
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("chunkedPublisher-out-0",
+                    MessageBuilder.withPayload(largePayload)
+                            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                            .setHeader(SolaceBinderHeaders.LARGE_MESSAGE_SUPPORT, true)
+                            .build());
+            log.info("Published large message of {} bytes", largePayload.length());
+        } catch (MessagingException e) {
+            log.error("Failed to publish large message of {} bytes", largePayload.length(), e);
+        }
     }
 
     @Bean

--- a/examples/manual-acknowledgment/pom.xml
+++ b/examples/manual-acknowledgment/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-manual-acknowledgment</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Manual Acknowledgment</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/manual-acknowledgment/src/main/java/ch/sbb/example/ManualAckApp.java
+++ b/examples/manual-acknowledgment/src/main/java/ch/sbb/example/ManualAckApp.java
@@ -11,6 +11,7 @@ import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.acks.AcknowledgmentCallback.Status;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -38,10 +39,16 @@ public class ManualAckApp {
     @Scheduled(fixedRate = 500)
     public void publish() {
         String payload = "msg-" + MSG_COUNT.incrementAndGet();
-        streamBridge.send("producer-out-0", MessageBuilder.withPayload(payload)
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("producer-out-0", MessageBuilder.withPayload(payload)
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+        } catch (MessagingException e) {
+            log.error("Failed to publish: {}", payload, e);
+        }
     }
 
     @Bean

--- a/examples/max-unacknowledged-messages/pom.xml
+++ b/examples/max-unacknowledged-messages/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-max-unacknowledged-messages</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Max Unacknowledged Messages</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/max-unacknowledged-messages/src/main/java/ch/sbb/example/MaxUnacknowledgedMessagesApp.java
+++ b/examples/max-unacknowledged-messages/src/main/java/ch/sbb/example/MaxUnacknowledgedMessagesApp.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.stream.binding.BindingsLifecycleController;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -107,11 +108,17 @@ public class MaxUnacknowledgedMessagesApp {
 
         for (int messageIndex = 0; messageIndex < totalMessages; messageIndex++) {
             String payload = "msg-" + messageIndex;
-            streamBridge.send("publisher-out-0", MessageBuilder.withPayload(payload)
-                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                    .build());
-            log.info("{} published {}", instanceName, payload);
+            // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window
+            // is exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+            try {
+                streamBridge.send("publisher-out-0", MessageBuilder.withPayload(payload)
+                        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                        .build());
+                log.info("{} published {}", instanceName, payload);
+            } catch (MessagingException e) {
+                log.error("{} failed to publish {}", instanceName, payload, e);
+            }
         }
     }
 

--- a/examples/metrics-monitoring/pom.xml
+++ b/examples/metrics-monitoring/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-metrics-monitoring</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Metrics Monitoring</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/metrics-monitoring/src/main/java/ch/sbb/example/MetricsMonitoringApp.java
+++ b/examples/metrics-monitoring/src/main/java/ch/sbb/example/MetricsMonitoringApp.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -36,11 +37,17 @@ public class MetricsMonitoringApp {
         if (count.get() < 5) {
             int c = count.incrementAndGet();
             String payload = "msg-" + c;
-            streamBridge.send("metricsPublisher-out-0", MessageBuilder.withPayload(payload)
-                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                    .build());
-            log.info("Published metric msg: {}", "msg-" + c);
+            // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window
+            // is exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+            try {
+                streamBridge.send("metricsPublisher-out-0", MessageBuilder.withPayload(payload)
+                        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                        .build());
+                log.info("Published metric msg: {}", "msg-" + c);
+            } catch (MessagingException e) {
+                log.error("Failed to publish metric msg: {}", "msg-" + c, e);
+            }
         }
     }
 

--- a/examples/micrometer-tracing/pom.xml
+++ b/examples/micrometer-tracing/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-micrometer-tracing</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Micrometer Tracing</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/micrometer-tracing/src/main/java/ch/sbb/example/MicrometerTracingApp.java
+++ b/examples/micrometer-tracing/src/main/java/ch/sbb/example/MicrometerTracingApp.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -27,11 +28,11 @@ public class MicrometerTracingApp {
 
     public static final BlockingQueue<TraceObservation> TRACING_LOGS = new LinkedBlockingQueue<>();
     private final AtomicInteger count = new AtomicInteger();
-    
+
     // Spring Boot automatically configures the Tracer
     private final Tracer tracer;
     private final StreamBridge streamBridge;
-    
+
     public MicrometerTracingApp(Tracer tracer, StreamBridge streamBridge) {
         this.tracer = tracer;
         this.streamBridge = streamBridge;
@@ -44,7 +45,7 @@ public class MicrometerTracingApp {
         if (count.get() < 3) {
             int c = count.incrementAndGet();
             String payload = "msg-" + c;
-            
+
             // Start a new span manually to observe trace propagation
             io.micrometer.tracing.Span newSpan = tracer.nextSpan().name("send-msg").start();
             try (io.micrometer.tracing.Tracer.SpanInScope ws = tracer.withSpan(newSpan)) {
@@ -52,11 +53,18 @@ public class MicrometerTracingApp {
                 String currentSpanId = newSpan.context().spanId();
                 log.info("Publishing msg {}. TraceID: {}, SpanID: {}", c, currentTraceId, currentSpanId);
                 TRACING_LOGS.offer(new TraceObservation("PUBLISHER", payload, currentTraceId, currentSpanId));
-                
-                streamBridge.send("tracingPublisher-out-0", MessageBuilder.withPayload(payload)
-                        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                        .build());
+
+                // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs
+                // window is exhausted), so always wrap the publish in a try/catch even though the binder retries
+                // transient failures.
+                try {
+                    streamBridge.send("tracingPublisher-out-0", MessageBuilder.withPayload(payload)
+                            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                            .build());
+                } catch (MessagingException e) {
+                    log.error("Failed to publish msg {}", payload, e);
+                }
             } finally {
                 newSpan.end();
             }

--- a/examples/multi-binder/README.md
+++ b/examples/multi-binder/README.md
@@ -110,22 +110,33 @@ public class MultiBinderApp {
     @Scheduled(fixedRate = 1000)
     public void publishToBrokers() {
         int c = count.getAndIncrement();
+        // streamBridge.send(...) can throw a MessagingException, so guard every publish.
         String msg1 = "msg-to-broker1-" + c;
-      streamBridge.send("fromBroker1-out-0", MessageBuilder.withPayload(msg1)
-        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-        .build());
-        log.info("Published to Broker 1: {}", msg1);
+        try {
+          streamBridge.send("fromBroker1-out-0", MessageBuilder.withPayload(msg1)
+            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+            .build());
+          log.info("Published to Broker 1: {}", msg1);
+        } catch (MessagingException e) {
+          log.error("Failed to publish to Broker 1: {}", msg1, e);
+        }
 
         String msg2 = "msg-to-broker2-" + c;
-      streamBridge.send("fromBroker2-out-0", MessageBuilder.withPayload(msg2)
-        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-        .build());
-        log.info("Published to Broker 2: {}", msg2);
+        try {
+          streamBridge.send("fromBroker2-out-0", MessageBuilder.withPayload(msg2)
+            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+            .build());
+          log.info("Published to Broker 2: {}", msg2);
+        } catch (MessagingException e) {
+          log.error("Failed to publish to Broker 2: {}", msg2, e);
+        }
     }
 }
 ```
+
+> Each `streamBridge.send(...)` is synchronous and can throw an `org.springframework.messaging.MessagingException` (for example once the producer's `sendRetryTimeoutMs`, default `60000`, is exhausted). Guard every publish independently so a failure against one broker does not skip the other. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 - `fromBroker1` publishes to broker 1.
 - `toBroker1` consumes from broker 1 — it receives messages from `fromBroker1`.

--- a/examples/multi-binder/pom.xml
+++ b/examples/multi-binder/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-multi-binder</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Multi-Binder</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/multi-binder/src/main/java/ch/sbb/example/MultiBinderApp.java
+++ b/examples/multi-binder/src/main/java/ch/sbb/example/MultiBinderApp.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -23,7 +24,7 @@ public class MultiBinderApp {
     private static final Logger log = LoggerFactory.getLogger(MultiBinderApp.class);
     public static final BlockingQueue<String> RECEIVED_1 = new LinkedBlockingQueue<>();
     public static final BlockingQueue<String> RECEIVED_2 = new LinkedBlockingQueue<>();
-    
+
     private final AtomicInteger count = new AtomicInteger(1);
     private final StreamBridge streamBridge;
 
@@ -36,19 +37,29 @@ public class MultiBinderApp {
     @Scheduled(fixedRate = 1000)
     public void publishToBrokers() {
         int c = count.getAndIncrement();
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
         String msg1 = "msg-to-broker1-" + c;
-        streamBridge.send("fromBroker1-out-0", MessageBuilder.withPayload(msg1)
-            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-            .build());
-        log.info("Published to Broker 1: {}", msg1);
-        
+        try {
+            streamBridge.send("fromBroker1-out-0", MessageBuilder.withPayload(msg1)
+                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                .build());
+            log.info("Published to Broker 1: {}", msg1);
+        } catch (MessagingException e) {
+            log.error("Failed to publish to Broker 1: {}", msg1, e);
+        }
+
         String msg2 = "msg-to-broker2-" + c;
-        streamBridge.send("fromBroker2-out-0", MessageBuilder.withPayload(msg2)
-            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-            .build());
-        log.info("Published to Broker 2: {}", msg2);
+        try {
+            streamBridge.send("fromBroker2-out-0", MessageBuilder.withPayload(msg2)
+                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                .build());
+            log.info("Published to Broker 2: {}", msg2);
+        } catch (MessagingException e) {
+            log.error("Failed to publish to Broker 2: {}", msg2, e);
+        }
     }
 
     @Bean

--- a/examples/nonpersistent-messaging/README.md
+++ b/examples/nonpersistent-messaging/README.md
@@ -82,16 +82,20 @@ public class NonPersistentApp {
     @Scheduled(fixedRate = 500)
     public void publish() {
         String msg = "direct-msg-" + System.currentTimeMillis();
-      streamBridge.send("directPublisher-out-0", MessageBuilder.withPayload(msg)
-          .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-          .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-          .build());
+      try {
+        streamBridge.send("directPublisher-out-0", MessageBuilder.withPayload(msg)
+            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+            .build());
         log.info("Published Direct msg: {}", msg);
+      } catch (MessagingException e) {
+        log.error("Failed to publish Direct msg: {}", msg, e);
+      }
     }
 }
 ```
 
-  Publishes a timestamped message as a Direct (non-persistent) message. The sample still sets the standard 30 second TTL and `solace_dmqEligible=true` headers for consistency with the rest of the suite, even though Direct messages are not spooled to a DMQ because no queue is involved.
+  Publishes a timestamped message as a Direct (non-persistent) message. The sample still sets the standard 30 second TTL and `solace_dmqEligible=true` headers for consistency with the rest of the suite, even though Direct messages are not spooled to a DMQ because no queue is involved. `streamBridge.send(...)` is wrapped in a `try/catch` for `org.springframework.messaging.MessagingException` — even for Direct messaging the call is synchronous and can throw once the producer's `sendRetryTimeoutMs` (default `60000`) is exhausted, so producers must always be prepared to catch it. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 ```java
 @Bean

--- a/examples/nonpersistent-messaging/pom.xml
+++ b/examples/nonpersistent-messaging/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-nonpersistent-messaging</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Non-Persistent Messaging</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/nonpersistent-messaging/src/main/java/ch/sbb/example/NonPersistentApp.java
+++ b/examples/nonpersistent-messaging/src/main/java/ch/sbb/example/NonPersistentApp.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -35,11 +36,17 @@ public class NonPersistentApp {
     @Scheduled(fixedRate = 500)
     public void publish() {
         String msg = "direct-msg-" + System.currentTimeMillis();
-        streamBridge.send("directPublisher-out-0", MessageBuilder.withPayload(msg)
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        log.info("Published Direct msg: {}", msg);
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("directPublisher-out-0", MessageBuilder.withPayload(msg)
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            log.info("Published Direct msg: {}", msg);
+        } catch (MessagingException e) {
+            log.error("Failed to publish Direct msg: {}", msg, e);
+        }
     }
 
     @Bean

--- a/examples/oauth2-authentication/README.md
+++ b/examples/oauth2-authentication/README.md
@@ -100,16 +100,20 @@ public class OAuth2App {
 
     @Scheduled(fixedRate = 500)
     public void publish() {
-      streamBridge.send("oauthPublisher-out-0", MessageBuilder.withPayload("oauth-secured-msg")
-          .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-          .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-          .build());
+      try {
+        streamBridge.send("oauthPublisher-out-0", MessageBuilder.withPayload("oauth-secured-msg")
+            .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+            .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+            .build());
         log.info("Published authenticated message");
+      } catch (MessagingException e) {
+        log.error("Failed to publish authenticated message", e);
+      }
     }
 }
 ```
 
-  The application code is still effectively identical to a standard publisher/consumer, apart from the standard 30 second TTL and `solace_dmqEligible=true` headers on outbound messages. OAuth2 authentication is handled entirely by the binder and Spring Security — no authentication code is needed in the application beans.
+  The application code is still effectively identical to a standard publisher/consumer, apart from the standard 30 second TTL and `solace_dmqEligible=true` headers on outbound messages, plus the `try/catch` around `streamBridge.send(...)`. That publish is synchronous and can throw an `org.springframework.messaging.MessagingException` once the producer's `sendRetryTimeoutMs` (default `60000`) is exhausted, so producers must always catch it. OAuth2 authentication is handled entirely by the binder and Spring Security — no authentication code is needed in the application beans. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 **How the authentication flow works:**
 

--- a/examples/oauth2-authentication/pom.xml
+++ b/examples/oauth2-authentication/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-oauth2-authentication</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - OAuth2 Authentication</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/oauth2-authentication/src/main/java/ch/sbb/example/OAuth2App.java
+++ b/examples/oauth2-authentication/src/main/java/ch/sbb/example/OAuth2App.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -31,11 +32,17 @@ public class OAuth2App {
 
     @Scheduled(fixedRate = 500)
     public void publish() {
-        streamBridge.send("oauthPublisher-out-0", MessageBuilder.withPayload("oauth-secured-msg")
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        log.info("Published authenticated message");
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("oauthPublisher-out-0", MessageBuilder.withPayload("oauth-secured-msg")
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            log.info("Published authenticated message");
+        } catch (MessagingException e) {
+            log.error("Failed to publish authenticated message", e);
+        }
     }
 
     @Bean

--- a/examples/partitioned-queues/pom.xml
+++ b/examples/partitioned-queues/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-partitioned-queues</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Partitioned Queues</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/partitioned-queues/src/main/java/ch/sbb/example/PartitionedQueuesApp.java
+++ b/examples/partitioned-queues/src/main/java/ch/sbb/example/PartitionedQueuesApp.java
@@ -12,6 +12,7 @@ import org.springframework.cloud.stream.binding.BindingsLifecycleController;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -97,8 +98,14 @@ public class PartitionedQueuesApp {
                     .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
                     .setHeader(SolaceBinderHeaders.PARTITION_KEY, key)
                     .build();
-            streamBridge.send("partitionedPublisher-out-0", msg);
-            log.info("Published: {} with partitionKey={}", payload, key);
+            // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window
+            // is exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+            try {
+                streamBridge.send("partitionedPublisher-out-0", msg);
+                log.info("Published: {} with partitionKey={}", payload, key);
+            } catch (MessagingException e) {
+                log.error("Failed to publish: {} with partitionKey={}", payload, key, e);
+            }
         }
     }
 

--- a/examples/pause-resume-bindings/README.md
+++ b/examples/pause-resume-bindings/README.md
@@ -77,13 +77,19 @@ management:
 
 ```java
 @PostMapping("/send")
-public String publish(@RequestBody String payload) {
-  streamBridge.send("example/pausable/topic", MessageBuilder.withPayload(payload)
-      .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-      .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-      .build());
+public ResponseEntity<String> publish(@RequestBody String payload) {
+  try {
+    streamBridge.send("example/pausable/topic", MessageBuilder.withPayload(payload)
+        .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+        .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+        .build());
     log.info("Published to pausable topic: {}", payload);
-    return "Sent " + payload;
+    return ResponseEntity.ok("Sent " + payload);
+  } catch (MessagingException e) {
+    log.error("Failed to publish to pausable topic: {}", payload, e);
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .body("Failed to send " + payload + ": " + e.getMessage());
+  }
 }
 
 @Bean
@@ -96,6 +102,8 @@ public Consumer<String> pausableConsumer() {
 ```
 
 The `/send` helper endpoint publishes test messages into the same destination that the pausable consumer reads from, with a 30 second TTL and `solace_dmqEligible=true`. The pause/resume functionality itself is still provided by the Spring Cloud Stream framework and the Solace binder — no special pause logic is needed in the consumer.
+
+Because the endpoint publishes straight from the request thread, `streamBridge.send(...)` is wrapped in a `try/catch` for `org.springframework.messaging.MessagingException`. That publish is synchronous and can throw once the producer's `sendRetryTimeoutMs` (default `60000`, set `0` to disable) is exhausted; catching it lets the endpoint return an HTTP `503` instead of parking the request and failing unhandled. See [Failed Producer Message Error Handling](../../API.md#failed-producer-message-error-handling).
 
 ## What to Observe
 

--- a/examples/pause-resume-bindings/pom.xml
+++ b/examples/pause-resume-bindings/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-pause-resume-bindings</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Pause Resume Bindings</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/pause-resume-bindings/src/main/java/ch/sbb/example/PauseResumeApp.java
+++ b/examples/pause-resume-bindings/src/main/java/ch/sbb/example/PauseResumeApp.java
@@ -7,6 +7,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,13 +34,22 @@ public class PauseResumeApp {
     public static void main(String[] args) { SpringApplication.run(PauseResumeApp.class, args); }
 
     @PostMapping("/send")
-    public String publish(@RequestBody String payload) {
-        streamBridge.send("example/pausable/topic", MessageBuilder.withPayload(payload)
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        log.info("Published to pausable topic: {}", payload);
-        return "Sent " + payload;
+    public ResponseEntity<String> publish(@RequestBody String payload) {
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted, or while the producer binding is paused). Publishing straight from this request thread, so always
+        // catch it and return a proper HTTP error response instead of letting the request fail unhandled.
+        try {
+            streamBridge.send("example/pausable/topic", MessageBuilder.withPayload(payload)
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            log.info("Published to pausable topic: {}", payload);
+            return ResponseEntity.ok("Sent " + payload);
+        } catch (MessagingException e) {
+            log.error("Failed to publish to pausable topic: {}", payload, e);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body("Failed to send " + payload + ": " + e.getMessage());
+        }
     }
 
     @Bean

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-binder-examples</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <packaging>pom</packaging>
     <name>Solace Binder Examples</name>
     <description>Runnable examples for all features of the Spring Cloud Stream Binder for Solace PubSub+</description>

--- a/examples/programmatic-binding-control/pom.xml
+++ b/examples/programmatic-binding-control/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-programmatic-binding-control</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Programmatic Binding Control</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/programmatic-binding-control/src/main/java/ch/sbb/example/ProgrammaticBindingControlApp.java
+++ b/examples/programmatic-binding-control/src/main/java/ch/sbb/example/ProgrammaticBindingControlApp.java
@@ -8,6 +8,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.binding.BindingsLifecycleController;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,13 +43,22 @@ public class ProgrammaticBindingControlApp {
     }
 
     @PostMapping("/send")
-    public String publish(@RequestBody String payload) {
-        streamBridge.send("controlledPublisher-out-0", MessageBuilder.withPayload(payload)
-                .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
-                .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
-                .build());
-        log.info("Published to controlled topic: {}", payload);
-        return "Sent " + payload;
+    public ResponseEntity<String> publish(@RequestBody String payload) {
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted, or while the producer binding is stopped). Publishing straight from this request thread, so always
+        // catch it and return a proper HTTP error response instead of letting the request fail unhandled.
+        try {
+            streamBridge.send("controlledPublisher-out-0", MessageBuilder.withPayload(payload)
+                    .setHeader(SolaceHeaders.TIME_TO_LIVE, Duration.ofSeconds(30).toMillis())
+                    .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
+                    .build());
+            log.info("Published to controlled topic: {}", payload);
+            return ResponseEntity.ok("Sent " + payload);
+        } catch (MessagingException e) {
+            log.error("Failed to publish to controlled topic: {}", payload, e);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body("Failed to send " + payload + ": " + e.getMessage());
+        }
     }
 
     @PostMapping("/bindings/start")

--- a/examples/publisher-confirms/pom.xml
+++ b/examples/publisher-confirms/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-publisher-confirms</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Publisher Confirms</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/publisher-confirms/src/main/java/ch/sbb/example/PublisherConfirmsApp.java
+++ b/examples/publisher-confirms/src/main/java/ch/sbb/example/PublisherConfirmsApp.java
@@ -12,6 +12,7 @@ import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
 
@@ -55,12 +56,13 @@ public class PublisherConfirmsApp {
 
 @Service
 class PublishService {
+    private static final Logger log = LoggerFactory.getLogger(PublishService.class);
     private final StreamBridge streamBridge;
-    
+
     public PublishService(StreamBridge streamBridge) {
         this.streamBridge = streamBridge;
     }
-    
+
     public boolean publishAndWait(String payload) throws Exception {
         CorrelationData correlationData = new CorrelationData();
         Message<String> msg = MessageBuilder.withPayload(payload)
@@ -68,9 +70,16 @@ class PublishService {
                 .setHeader(SolaceHeaders.DMQ_ELIGIBLE, true)
                 .setHeader(SolaceBinderHeaders.CONFIRM_CORRELATION, correlationData)
                 .build();
-        
-        streamBridge.send("confirmPublisher-out-0", msg);
-        
+
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("confirmPublisher-out-0", msg);
+        } catch (MessagingException e) {
+            log.error("Failed to publish: {}", payload, e);
+            throw e;
+        }
+
         try {
             // Wait for broker ACK
             correlationData.getFuture().get(5, TimeUnit.SECONDS);

--- a/examples/queue-provisioning-options/pom.xml
+++ b/examples/queue-provisioning-options/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-queue-provisioning-options</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Queue Provisioning Options</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/solace-headers/pom.xml
+++ b/examples/solace-headers/pom.xml
@@ -13,13 +13,13 @@
 
     <groupId>ch.sbb.solace.examples</groupId>
     <artifactId>solace-example-solace-headers</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
     <name>Solace Example - Solace Headers</name>
 
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2025.1.2</spring-cloud.version>
-        <solace-binder.version>9.2.0</solace-binder.version>
+        <solace-binder.version>9.3.0</solace-binder.version>
         <testcontainers-solace.version>2.0.4</testcontainers-solace.version>
         <testcontainers.version>2.0.4</testcontainers.version>
     </properties>

--- a/examples/solace-headers/src/main/java/ch/sbb/example/SolaceHeadersApp.java
+++ b/examples/solace-headers/src/main/java/ch/sbb/example/SolaceHeadersApp.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -52,8 +53,14 @@ public class SolaceHeadersApp {
                 .setHeader("custom-org-id", "ORG-" + index)
                 .build();
 
-        streamBridge.send("headerPublisher-out-0", message);
-        log.info("Published with CorrelationID: corr-id-{}", index);
+        // StreamBridge.send(...) can throw a MessagingException (e.g. once the producer's sendRetryTimeoutMs window is
+        // exhausted), so always wrap the publish in a try/catch even though the binder retries transient failures.
+        try {
+            streamBridge.send("headerPublisher-out-0", message);
+            log.info("Published with CorrelationID: corr-id-{}", index);
+        } catch (MessagingException e) {
+            log.error("Failed to publish with CorrelationID: corr-id-{}", index, e);
+        }
     }
 
     @Bean

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>ch.sbb</groupId>
     <artifactId>spring-cloud-stream-binder-solace</artifactId>
-    <version>9.2.0</version>
+    <version>9.3.0</version>
 
     <name>Spring Cloud Stream Binder Solace</name>
     <description>A Spring Cloud Stream Binder implementation using the Solace Java API (JCSMP)</description>

--- a/src/main/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandler.java
+++ b/src/main/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandler.java
@@ -24,10 +24,12 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.StringUtils;
 
+import java.time.Duration;
 import java.util.*;
 
 @Slf4j
 public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
+    private static final Duration SEND_RETRY_BACKOFF = Duration.ofSeconds(1);
     private final String id = UUID.randomUUID().toString();
     private final DestinationType configDestinationType;
     private final Destination configDestination;
@@ -122,7 +124,7 @@ public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
                 log.debug("Publishing message {} of {} to destination [ {}:{} ] <message handler ID: {}>",
                         i + 1, smfMessages.size(), targetDestination instanceof Topic ? "TOPIC" : "QUEUE",
                         targetDestination, id);
-                producer.send(smfMessage, targetDestination);
+                sendWithRetry(smfMessage, targetDestination);
             }
         } catch (JCSMPException e) {
             throw handleMessagingException(correlationKey, "Unable to send message(s) to destination", e);
@@ -131,6 +133,43 @@ public class JCSMPOutboundMessageHandler implements MessageHandler, Lifecycle {
                 for (XMLMessage smfMessage : smfMessages) {
                     solaceMeterAccessor.get().recordMessage(properties.getBindingName(), smfMessage);
                 }
+            }
+        }
+    }
+
+    /**
+     * Publishes a single SMF message, retrying transient {@link JCSMPException}s until the configured
+     * {@link SolaceProducerProperties#getSendRetryTimeoutMs() sendRetryTimeoutMs} window is exhausted.
+     * When the retry window is {@code 0} (disabled) or has elapsed, the last failure is propagated so the caller can
+     * surface it as a {@link MessagingException}.
+     */
+    private void sendWithRetry(XMLMessage smfMessage, Destination targetDestination) throws JCSMPException {
+        long retryTimeoutMs = properties.getExtension().getSendRetryTimeoutMs();
+        long deadlineNanos = System.nanoTime() + Duration.ofMillis(Math.max(retryTimeoutMs, 0L)).toNanos();
+        int attempt = 1;
+        while (true) {
+            if (producer.isClosed() || !isRunning()) {
+                throw new ClosedFacilityException("Producer is already closed this can never recover. producer-id=%s".formatted(id));
+            }
+            try {
+                producer.send(smfMessage, targetDestination);
+                return;
+            } catch (JCSMPException e) {
+                // Retry disabled or retry window exhausted -> propagate the failure as a MessagingException.
+                if (retryTimeoutMs <= 0 || System.nanoTime() - deadlineNanos >= 0) {
+                    throw e;
+                }
+                log.info("Failed to publish message to destination [ {} ] on attempt {}. Retrying in {} ms "
+                                + "(retry window: {} ms). <message handler ID: {}>",
+                        targetDestination, attempt, SEND_RETRY_BACKOFF.toMillis(), retryTimeoutMs, id, e);
+                try {
+                    Thread.sleep(SEND_RETRY_BACKOFF.toMillis());
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    e.addSuppressed(ie);
+                    throw e;
+                }
+                attempt++;
             }
         }
     }

--- a/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
+++ b/src/main/java/com/solace/spring/cloud/stream/binder/properties/SolaceProducerProperties.java
@@ -73,4 +73,19 @@ public class SolaceProducerProperties extends SolaceCommonProperties {
      * Default: null (inherit {@code JCSMPProperties.PUB_ACK_WINDOW_SIZE})
      */
     private Integer pubAckWindowSize;
+
+    /**
+     * Time window in milliseconds during which a failed synchronous publish ({@code producer.send(...)}) is retried
+     * before the send ultimately fails. When a publish attempt throws, the binder keeps retrying until this duration
+     * elapses, after which it re-throws the failure as an {@link org.springframework.messaging.MessagingException}.
+     * <p>
+     * Set to {@code 0} to disable retrying: the message handler then performs a single publish attempt and immediately
+     * propagates any failure as a {@link org.springframework.messaging.MessagingException}.
+     * <p>
+     * Note: retrying only mitigates transient, synchronous publish failures. Regardless of this setting,
+     * {@code StreamBridge.send(...)} / the outbound message handler can still throw a
+     * {@link org.springframework.messaging.MessagingException}, so callers must always be prepared to catch it.
+     * Default: 60000 (60 seconds).
+     */
+    private long sendRetryTimeoutMs = 60000;
 }

--- a/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
+++ b/src/test/java/com/solace/spring/cloud/stream/binder/outbound/JCSMPOutboundMessageHandlerTest.java
@@ -266,6 +266,8 @@ public class JCSMPOutboundMessageHandlerTest {
         if (success) {
             messageHandler.handleMessage(message);
         } else {
+            // Disable send retry so this test exercises the immediate-throw path without the default 60s retry window.
+            producerProperties.getExtension().setSendRetryTimeoutMs(0);
             JCSMPException exception = new JCSMPException("Expected exception");
             Mockito.doThrow(exception)
                     .when(messageProducer)
@@ -277,6 +279,64 @@ public class JCSMPOutboundMessageHandlerTest {
 
         Mockito.verify(solaceMeterAccessor, Mockito.times(1))
                 .recordMessage(Mockito.eq(producerProperties.getBindingName()), any());
+    }
+
+    @Test
+    public void test_send_retriedThenSucceeds() throws Exception {
+        producerProperties.getExtension().setSendRetryTimeoutMs(30000);
+        messageHandler.start();
+
+        // Fail the first publish attempt, then succeed on the retry.
+        Mockito.doThrow(new JCSMPException("transient"))
+                .doNothing()
+                .when(messageProducer)
+                .send(any(XMLMessage.class), any(Destination.class));
+
+        Message<String> message = MessageBuilder.withPayload(RandomStringUtils.randomAlphanumeric(100)).build();
+        assertDoesNotThrow(() -> messageHandler.handleMessage(message));
+
+        Mockito.verify(messageProducer, Mockito.times(2))
+                .send(any(XMLMessage.class), any(Destination.class));
+    }
+
+    @Test
+    public void test_send_retryDisabled_throwsImmediately() throws Exception {
+        producerProperties.getExtension().setSendRetryTimeoutMs(0);
+        messageHandler.start();
+
+        JCSMPException exception = new JCSMPException("boom");
+        Mockito.doThrow(exception)
+                .when(messageProducer)
+                .send(any(XMLMessage.class), any(Destination.class));
+
+        Message<String> message = MessageBuilder.withPayload(RandomStringUtils.randomAlphanumeric(100)).build();
+        assertThatThrownBy(() -> messageHandler.handleMessage(message))
+                .isInstanceOf(MessagingException.class)
+                .hasCause(exception);
+
+        // With retry disabled only a single publish attempt is made.
+        Mockito.verify(messageProducer, Mockito.times(1))
+                .send(any(XMLMessage.class), any(Destination.class));
+    }
+
+    @Test
+    public void test_send_retryExhausted_throwsMessagingException() throws Exception {
+        producerProperties.getExtension().setSendRetryTimeoutMs(100);
+        messageHandler.start();
+
+        JCSMPException exception = new JCSMPException("boom");
+        Mockito.doThrow(exception)
+                .when(messageProducer)
+                .send(any(XMLMessage.class), any(Destination.class));
+
+        Message<String> message = MessageBuilder.withPayload(RandomStringUtils.randomAlphanumeric(100)).build();
+        assertThatThrownBy(() -> messageHandler.handleMessage(message))
+                .isInstanceOf(MessagingException.class)
+                .hasCause(exception);
+
+        // The publish is retried at least once before the retry window is exhausted.
+        Mockito.verify(messageProducer, Mockito.atLeast(2))
+                .send(any(XMLMessage.class), any(Destination.class));
     }
 
     @Test


### PR DESCRIPTION
It is configurable, opt-out as described by setting sendRetryTimeout="0s"
Main reason: To enhance reliability